### PR TITLE
add ata in contract

### DIFF
--- a/src/bot/arb_bot.js
+++ b/src/bot/arb_bot.js
@@ -109,7 +109,6 @@ export class ArbBot {
 
             const handler = new MintXHandler(mintX, mintXData, this.connection, true);
             await handler.init();
-            await utils.createATATokenAccount(handler.getMintX(), this.connection, this.userKeypair, true);
             this.runningMintX.push(handler);
             this.runningMintX = [...this.runningMintX.slice(-this.maxRunningMintX)]
             console.log("processMintX Success:", mintX)

--- a/src/idl/idl.json
+++ b/src/idl/idl.json
@@ -56,6 +56,10 @@
           "address": "B2kcKQCZUWvK59w9V9n7oDiFwqrh5FowymgpsKZV5NHu"
         },
         {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
           "name": "account_0",
           "writable": true,
           "optional": true
@@ -267,6 +271,10 @@
           "name": "recipient",
           "writable": true,
           "address": "B2kcKQCZUWvK59w9V9n7oDiFwqrh5FowymgpsKZV5NHu"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         },
         {
           "name": "account_0",
@@ -610,6 +618,10 @@
           "name": "recipient",
           "writable": true,
           "address": "B2kcKQCZUWvK59w9V9n7oDiFwqrh5FowymgpsKZV5NHu"
+        },
+        {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         },
         {
           "name": "account_0",


### PR DESCRIPTION
在合约中支持token account的创建和关闭，减少账户租金占用
Support the creation and closure of token accounts in the smart contract to reduce the occupancy of account rent.

reference transaction： https://solscan.io/tx/5dZkriFvk59CpoWmJNAztpS4UrKZSQYWvFPiRMsW2N9V9wxRXefN1ARXV5gE8h3yhHd8C6XYffx5nuUrc9MUQJL9